### PR TITLE
feat: add BookmarkNode for embed-link (埋め込みリンク) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `@becraft/sdk` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Support for the BeCraft **埋め込みリンク (bookmark) ノード**. The parser now
+  recognizes the `<a class="bookmark-card">` markup emitted by the backend's
+  `bookmark_to_html` and produces a new `BookmarkNode` (`type: 'bookmark'`)
+  carrying `url` / `title` / `description` / `thumbnailUrl` / `faviconUrl`.
+  `BeCraftHTMLRenderer` renders it with the same `bookmark-card` BEM structure,
+  and a `bookmarkNodeRenderer` override is available via `HTMLRendererConfig`.
+  Bookmarks without OGP metadata fall back to a plain anchor, matching the
+  backend output.
+
 ## [0.2.0] - 2026-04-23
 
 ### ⚠ BREAKING CHANGES
@@ -49,6 +62,7 @@ Previous releases are not documented here. See the
 [GitHub Releases](https://github.com/BeCraft-CMS/becraft-sdk/releases)
 page for release artifacts.
 
+[unreleased]: https://github.com/BeCraft-CMS/becraft-sdk/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/BeCraft-CMS/becraft-sdk/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/BeCraft-CMS/becraft-sdk/releases/tag/v0.1.2
 [#2]: https://github.com/BeCraft-CMS/becraft-sdk/issues/2

--- a/src/parser/html-parser.test.ts
+++ b/src/parser/html-parser.test.ts
@@ -196,6 +196,66 @@ describe('parseHtml', () => {
     });
   });
 
+  describe('bookmark', () => {
+    it('should parse a full bookmark card', () => {
+      const html =
+        '<a class="bookmark-card" href="https://example.com/article" rel="noopener noreferrer" target="_blank">' +
+        '<div class="bookmark-card__thumbnail"><img src="https://example.com/thumb.png" alt=""></div>' +
+        '<div class="bookmark-card__body">' +
+        '<p class="bookmark-card__title">Example Title</p>' +
+        '<p class="bookmark-card__description">Example description text</p>' +
+        '<div class="bookmark-card__footer">' +
+        '<img class="bookmark-card__favicon" src="https://example.com/favicon.ico" alt="">' +
+        '<span class="bookmark-card__url">https://example.com/article</span>' +
+        '</div></div></a>';
+      const result = parseHtml(html);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('bookmark');
+      if (result[0].type === 'bookmark') {
+        expect(result[0].url).toBe('https://example.com/article');
+        expect(result[0].title).toBe('Example Title');
+        expect(result[0].description).toBe('Example description text');
+        expect(result[0].thumbnailUrl).toBe('https://example.com/thumb.png');
+        expect(result[0].faviconUrl).toBe('https://example.com/favicon.ico');
+      }
+    });
+
+    it('should parse a bookmark card without optional fields', () => {
+      const html =
+        '<a class="bookmark-card" href="https://example.com" rel="noopener noreferrer" target="_blank">' +
+        '<div class="bookmark-card__thumbnail"></div>' +
+        '<div class="bookmark-card__body">' +
+        '<div class="bookmark-card__footer">' +
+        '<span class="bookmark-card__url">https://example.com</span>' +
+        '</div></div></a>';
+      const result = parseHtml(html);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('bookmark');
+      if (result[0].type === 'bookmark') {
+        expect(result[0].url).toBe('https://example.com');
+        expect(result[0].title).toBeUndefined();
+        expect(result[0].description).toBeUndefined();
+        expect(result[0].thumbnailUrl).toBeUndefined();
+        expect(result[0].faviconUrl).toBeUndefined();
+      }
+    });
+
+    it('should parse a plain anchor (bookmark fallback) as a link', () => {
+      // BE は OGP メタが無い bookmark をクラス無しのプレーンアンカーで出力する
+      const html =
+        '<a href="https://example.com" rel="noopener noreferrer" target="_blank">https://example.com</a>';
+      const result = parseHtml(html);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('link');
+      if (result[0].type === 'link') {
+        expect(result[0].url).toBe('https://example.com');
+      }
+    });
+  });
+
   describe('linebreak', () => {
     it('should parse br tag in paragraph', () => {
       const html = '<p>Hello<br>World</p>';

--- a/src/parser/html-parser.ts
+++ b/src/parser/html-parser.ts
@@ -13,6 +13,7 @@ import {
   AudioNode,
   EmbedNode,
   ObjectNode,
+  BookmarkNode,
   ParagraphNode,
   QuoteNode,
   HeadingNode,
@@ -190,6 +191,26 @@ const parseBeCraftMedia = (element: Element): MediaNode => {
   return MediaNode.from([], gridStyle);
 };
 
+const hasClass = (element: Element, className: string): boolean =>
+  (element.getAttribute('class') || '').split(/\s+/).includes(className);
+
+// BeCraft の埋め込みリンク (bookmark) は BE の bookmark_to_html が
+// `<a class="bookmark-card" ...>` で出力する。OGP メタ (title / description /
+// thumbnail / favicon) が 1 つも無い場合は BE 側でクラス無しのプレーン
+// アンカーにフォールバックするため、それは通常の LinkNode として扱えばよい。
+const parseBookmarkCard = (element: Element): BookmarkNode => {
+  const url = element.getAttribute('href') || '';
+  const title = element.querySelector('.bookmark-card__title')?.textContent?.trim() || undefined;
+  const description =
+    element.querySelector('.bookmark-card__description')?.textContent?.trim() || undefined;
+  const thumbnailUrl =
+    element.querySelector('.bookmark-card__thumbnail img')?.getAttribute('src') || undefined;
+  const faviconUrl =
+    element.querySelector('.bookmark-card__favicon')?.getAttribute('src') || undefined;
+
+  return BookmarkNode.from({ url, title, description, thumbnailUrl, faviconUrl });
+};
+
 const parseElement = (element: Element): ParsedHtmlNode => {
   const tagName = element.tagName.toLowerCase();
 
@@ -295,6 +316,9 @@ const parseElement = (element: Element): ParsedHtmlNode => {
     }
 
     case 'a': {
+      if (hasClass(element, 'bookmark-card')) {
+        return parseBookmarkCard(element);
+      }
       const url = element.getAttribute('href') || '';
       const children = Array.from(element.childNodes).flatMap((child) =>
         parseInlineContent(child, element),

--- a/src/parser/nodes.test.ts
+++ b/src/parser/nodes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { MediaNode } from './nodes';
+import { MediaNode, BookmarkNode } from './nodes';
 
 describe('MediaNode', () => {
   describe('constructor', () => {
@@ -209,6 +209,45 @@ describe('MediaNode', () => {
       expect(node.items[0].key).toBe('');
       expect(node.items[0].alt).toBe('');
       expect(node.items[0].caption).toBe('');
+    });
+  });
+});
+
+describe('BookmarkNode', () => {
+  describe('constructor', () => {
+    it('should create BookmarkNode with url only', () => {
+      const node = new BookmarkNode({ url: 'https://example.com' });
+      expect(node.type).toBe('bookmark');
+      expect(node.url).toBe('https://example.com');
+      expect(node.title).toBeUndefined();
+      expect(node.description).toBeUndefined();
+      expect(node.thumbnailUrl).toBeUndefined();
+      expect(node.faviconUrl).toBeUndefined();
+    });
+
+    it('should create BookmarkNode with all fields', () => {
+      const node = new BookmarkNode({
+        url: 'https://example.com/article',
+        title: 'Title',
+        description: 'Description',
+        thumbnailUrl: 'https://example.com/thumb.png',
+        faviconUrl: 'https://example.com/favicon.ico',
+      });
+      expect(node.url).toBe('https://example.com/article');
+      expect(node.title).toBe('Title');
+      expect(node.description).toBe('Description');
+      expect(node.thumbnailUrl).toBe('https://example.com/thumb.png');
+      expect(node.faviconUrl).toBe('https://example.com/favicon.ico');
+    });
+  });
+
+  describe('from static method', () => {
+    it('should create BookmarkNode from input', () => {
+      const node = BookmarkNode.from({ url: 'https://example.com', title: 'Title' });
+      expect(node).toBeInstanceOf(BookmarkNode);
+      expect(node.type).toBe('bookmark');
+      expect(node.url).toBe('https://example.com');
+      expect(node.title).toBe('Title');
     });
   });
 });

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -53,6 +53,14 @@ export type ObjectNodeInput = {
   height?: string;
 };
 
+export type BookmarkNodeInput = {
+  url: string;
+  title?: string;
+  description?: string;
+  thumbnailUrl?: string;
+  faviconUrl?: string;
+};
+
 export type TableCellNodeInput = {
   headerState: 0 | 1 | 2 | 3;
   colSpan: number;
@@ -71,6 +79,7 @@ export type ContentNode =
   | AudioNode
   | EmbedNode
   | ObjectNode
+  | BookmarkNode
   | ParagraphNode
   | QuoteNode
   | HeadingNode
@@ -265,6 +274,27 @@ export class ObjectNode {
 
   static from(input: ObjectNodeInput): ObjectNode {
     return new ObjectNode(input);
+  }
+}
+
+export class BookmarkNode {
+  readonly type: 'bookmark' = 'bookmark';
+  readonly url: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly thumbnailUrl?: string;
+  readonly faviconUrl?: string;
+
+  constructor(input: BookmarkNodeInput) {
+    this.url = input.url;
+    this.title = input.title;
+    this.description = input.description;
+    this.thumbnailUrl = input.thumbnailUrl;
+    this.faviconUrl = input.faviconUrl;
+  }
+
+  static from(input: BookmarkNodeInput): BookmarkNode {
+    return new BookmarkNode(input);
   }
 }
 

--- a/src/parser/server-parser-test-cases.ts
+++ b/src/parser/server-parser-test-cases.ts
@@ -136,6 +136,30 @@ export const runServerParserTests = (
       expect(result[0].type).toBe('audio');
     });
 
+    it('should parse bookmark cards', () => {
+      const result = parseHtmlOnServer(
+        '<a class="bookmark-card" href="https://example.com/article" rel="noopener noreferrer" target="_blank">' +
+          '<div class="bookmark-card__thumbnail"><img src="https://example.com/thumb.png" alt=""></div>' +
+          '<div class="bookmark-card__body">' +
+          '<p class="bookmark-card__title">Example Title</p>' +
+          '<p class="bookmark-card__description">Example description</p>' +
+          '<div class="bookmark-card__footer">' +
+          '<img class="bookmark-card__favicon" src="https://example.com/favicon.ico" alt="">' +
+          '<span class="bookmark-card__url">https://example.com/article</span>' +
+          '</div></div></a>',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('bookmark');
+      if (result[0].type === 'bookmark') {
+        expect(result[0].url).toBe('https://example.com/article');
+        expect(result[0].title).toBe('Example Title');
+        expect(result[0].description).toBe('Example description');
+        expect(result[0].thumbnailUrl).toBe('https://example.com/thumb.png');
+        expect(result[0].faviconUrl).toBe('https://example.com/favicon.ico');
+      }
+    });
+
     it('should return empty array for empty string', () => {
       const result = parseHtmlOnServer('');
 

--- a/src/renderer/html-renderer.test.tsx
+++ b/src/renderer/html-renderer.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { BeCraftHTMLRenderer } from './html-renderer';
 import { parseHtml } from '../parser/html-parser';
-import { MediaNode } from '../parser/nodes';
+import { MediaNode, BookmarkNode } from '../parser/nodes';
 
 describe('BeCraftHTMLRenderer', () => {
   it('should render HTML paragraph', () => {
@@ -347,6 +347,79 @@ describe('BeCraftHTMLRenderer', () => {
       const object = container.querySelector('object');
       expect(object).toBeTruthy();
       expect(object?.getAttribute('data')).toBe('#');
+    });
+  });
+
+  describe('bookmark element', () => {
+    const fullCardHtml =
+      '<a class="bookmark-card" href="https://example.com/article" rel="noopener noreferrer" target="_blank">' +
+      '<div class="bookmark-card__thumbnail"><img src="https://example.com/thumb.png" alt=""></div>' +
+      '<div class="bookmark-card__body">' +
+      '<p class="bookmark-card__title">Example Title</p>' +
+      '<p class="bookmark-card__description">Example description</p>' +
+      '<div class="bookmark-card__footer">' +
+      '<img class="bookmark-card__favicon" src="https://example.com/favicon.ico" alt="">' +
+      '<span class="bookmark-card__url">https://example.com/article</span>' +
+      '</div></div></a>';
+
+    it('should render a full bookmark card', () => {
+      const nodes = parseHtml(fullCardHtml);
+      const { container } = render(<BeCraftHTMLRenderer nodes={nodes} />);
+
+      const card = container.querySelector('a.bookmark-card');
+      expect(card).toBeTruthy();
+      expect(card?.getAttribute('href')).toBe('https://example.com/article');
+      expect(card?.getAttribute('target')).toBe('_blank');
+      expect(card?.getAttribute('rel')).toBe('noopener noreferrer');
+      expect(card?.querySelector('.bookmark-card__title')?.textContent).toBe('Example Title');
+      expect(card?.querySelector('.bookmark-card__description')?.textContent).toBe(
+        'Example description',
+      );
+      expect(card?.querySelector('.bookmark-card__thumbnail img')?.getAttribute('src')).toBe(
+        'https://example.com/thumb.png',
+      );
+      expect(card?.querySelector('.bookmark-card__favicon')?.getAttribute('src')).toBe(
+        'https://example.com/favicon.ico',
+      );
+      expect(card?.querySelector('.bookmark-card__url')?.textContent).toBe(
+        'https://example.com/article',
+      );
+    });
+
+    it('should render a bookmark without optional fields as a plain anchor', () => {
+      const node = BookmarkNode.from({ url: 'https://example.com' });
+      const { container } = render(<BeCraftHTMLRenderer nodes={[node]} />);
+
+      const anchor = container.querySelector('a');
+      expect(anchor).toBeTruthy();
+      expect(anchor?.classList.contains('bookmark-card')).toBe(false);
+      expect(anchor?.getAttribute('href')).toBe('https://example.com');
+      expect(anchor?.textContent).toBe('https://example.com');
+    });
+
+    it('should sanitize javascript: URLs in bookmark href', () => {
+      const node = BookmarkNode.from({ url: 'javascript:alert(1)', title: 'Evil' });
+      const { container } = render(<BeCraftHTMLRenderer nodes={[node]} />);
+
+      const card = container.querySelector('a.bookmark-card');
+      expect(card).toBeTruthy();
+      expect(card?.getAttribute('href')).toBe('#');
+    });
+
+    it('should use a custom bookmarkNodeRenderer when provided', () => {
+      const node = BookmarkNode.from({ url: 'https://example.com', title: 'Title' });
+      const { container } = render(
+        <BeCraftHTMLRenderer
+          nodes={[node]}
+          config={{
+            bookmarkNodeRenderer: ({ node }) => <div data-testid="custom">{node.url}</div>,
+          }}
+        />,
+      );
+
+      expect(container.querySelector('[data-testid="custom"]')?.textContent).toBe(
+        'https://example.com',
+      );
     });
   });
 

--- a/src/renderer/html-renderer.tsx
+++ b/src/renderer/html-renderer.tsx
@@ -11,6 +11,7 @@ import {
   type AudioNode,
   type EmbedNode,
   type ObjectNode,
+  type BookmarkNode,
   type ParagraphNode,
   type QuoteNode,
   type HeadingNode,
@@ -57,6 +58,7 @@ export interface HTMLRendererConfig {
   audioNodeRenderer?: React.FC<NodeRendererProps<AudioNode>>;
   embedNodeRenderer?: React.FC<NodeRendererProps<EmbedNode>>;
   objectNodeRenderer?: React.FC<NodeRendererProps<ObjectNode>>;
+  bookmarkNodeRenderer?: React.FC<NodeRendererProps<BookmarkNode>>;
   paragraphNodeRenderer?: React.FC<NodeRendererProps<ParagraphNode>>;
   quoteNodeRenderer?: React.FC<NodeRendererProps<QuoteNode>>;
   headingNodeRenderer?: React.FC<NodeRendererProps<HeadingNode>>;
@@ -234,6 +236,45 @@ const ObjectNodeRenderer: React.FC<NodeRendererProps<ObjectNode>> = ({ node, con
       width={node.width}
       height={node.height}
     />
+  );
+};
+
+const BookmarkNodeRenderer: React.FC<NodeRendererProps<BookmarkNode>> = ({ node, config }) => {
+  if (config?.bookmarkNodeRenderer) {
+    return config.bookmarkNodeRenderer({ node, render: renderNode, config });
+  }
+
+  const href = sanitizeUrl(node.url);
+  const hasCard = !!(node.title || node.description || node.thumbnailUrl || node.faviconUrl);
+
+  // OGP メタが無い bookmark は BE 側でもプレーンアンカーにフォールバックするため、
+  // レンダラーでも同じ形（クラス無しの <a>）で出す。
+  if (!hasCard) {
+    return (
+      <a href={href} rel="noopener noreferrer" target="_blank">
+        {node.url}
+      </a>
+    );
+  }
+
+  // BE の bookmark_to_html と同じ BEM 構造を再現する。レイアウトはテナント側の
+  // CSS 契約（bookmark-card 系クラス）に委ねるため、ここではクラス名のみ担保する。
+  return (
+    <a className="bookmark-card" href={href} rel="noopener noreferrer" target="_blank">
+      <div className="bookmark-card__thumbnail">
+        {node.thumbnailUrl && <img src={node.thumbnailUrl} alt="" />}
+      </div>
+      <div className="bookmark-card__body">
+        {node.title && <p className="bookmark-card__title">{node.title}</p>}
+        {node.description && <p className="bookmark-card__description">{node.description}</p>}
+        <div className="bookmark-card__footer">
+          {node.faviconUrl && (
+            <img className="bookmark-card__favicon" src={node.faviconUrl} alt="" />
+          )}
+          <span className="bookmark-card__url">{node.url}</span>
+        </div>
+      </div>
+    </a>
   );
 };
 
@@ -511,6 +552,8 @@ const renderNode: RenderFn = (node, config) => {
       return <EmbedNodeRenderer node={node} render={renderNode} config={config} />;
     case 'object':
       return <ObjectNodeRenderer node={node} render={renderNode} config={config} />;
+    case 'bookmark':
+      return <BookmarkNodeRenderer node={node} render={renderNode} config={config} />;
 
     default:
       return null;


### PR DESCRIPTION
## 概要

BeCraft 側で追加された「埋め込みリンク (bookmark)」ノードを SDK でも扱えるようにする。BE の `bookmark_to_html` が出力する `<a class="bookmark-card">` をパースし、`BookmarkNode` として React レンダリングできる。

## 変更点

- **`BookmarkNode`** を追加(`type: 'bookmark'`、`url` / `title` / `description` / `thumbnailUrl` / `faviconUrl`。フィールド名は BE の `BlockEditorBookmark` に合わせた)
- **html-parser**: `<a class="bookmark-card">` を検出して `BookmarkNode` を生成。OGP メタなしで BE がプレーンアンカーにフォールバックしたものは従来どおり `LinkNode` として扱う
- **html-renderer**: BE と同じ `bookmark-card` BEM 構造で描画。`HTMLRendererConfig` に `bookmarkNodeRenderer` オーバーライドを追加し、独自コンポーネントへ差し替え可能に
- client / server(`linkedom`・`linkedom/worker`)両パーサーの回帰テストを追加
- CHANGELOG に Unreleased エントリを追加

## テスト

- `pnpm test`(node + workerd 両バンドル)green
- `pnpm lint` / `pnpm build`(型生成含む)green

## 動作確認

ローカルの becraft 本体で bookmark を含むコンテンツを公開し、becraft-sdk-example から取得 → `parseHtmlOnServer` → `BookmarkNode` → `BeCraftHTMLRenderer` で描画されることを確認済み。`bookmarkNodeRenderer` による独自カード差し替えも確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)