### PR TITLE
feat: 埋め込みタグに登録された HTML をそのまま描画する

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ npm install linkedom
 - `parseHtmlOnServer(html: string)` - HTML を AST に解析（Node.js / Cloudflare Workers / Vercel Edge, linkedom ベース）
 - `BeCraftHTMLRenderer` - HTML をレンダリングする React コンポーネント
 
+### 埋め込みタグ
+
+BeCraft の埋め込みタグセクションに登録された HTML は、タグや属性を一切落とさずそのまま描画される。
+配信 API の html では区間が HTML コメント（`<!-- #embedtag -->` / `<!-- /#embedtag -->`）で囲まれており、
+パーサーはこの区間を `EmbedTagNode`（原文の HTML を保持）として扱う。
+
+デフォルトの描画は `<div dangerouslySetInnerHTML>` による原文の挿入となる。
+`<script>` は HTML 仕様上 `innerHTML` 経由では実行されないため、
+スクリプトの実行が必要な埋め込み（HubSpot フォーム等）を扱う場合は
+`embedTagNodeRenderer` で独自に処理する。
+
+```tsx
+<BeCraftHTMLRenderer
+  nodes={nodes}
+  config={{
+    embedTagNodeRenderer: ({ node }) => <MyEmbed html={node.html} />,
+  }}
+/>
+```
+
 ## 型定義
 
 ```ts

--- a/src/parser/embed-tag-round-trip.test.tsx
+++ b/src/parser/embed-tag-round-trip.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { parseHTML } from 'linkedom';
+import { makeParseHtmlOnServer } from './server-html-parser';
+import { BeCraftHTMLRenderer } from '../renderer/html-renderer';
+
+const parseHtmlOnServer = makeParseHtmlOnServer(parseHTML as never);
+
+/**
+ * 「埋め込みタグに登録した HTML がそのまま表示される」という仕様の回帰テスト。
+ * 配信 API の html と同じ形（区間マーカー + 前後の本文）を入力に、
+ * パースから描画までを通して原文が保たれることを確認する。
+ *
+ * 対応: apps/serverside/interface/src/renderer/embed_tag.rs
+ *       specs/content/embed_tag.als (MarkerBasedPassthrough)
+ */
+describe('embed tag round trip', () => {
+  const deliver = (embed: string) =>
+    `<p>before</p><!-- #embedtag -->${embed}<!-- /#embedtag --><p>after</p>`;
+
+  const renderDelivered = (embed: string) => {
+    const nodes = parseHtmlOnServer(deliver(embed));
+    expect(nodes.map((node) => node.type)).toEqual(['paragraph', 'embedtag', 'paragraph']);
+    return renderToStaticMarkup(<BeCraftHTMLRenderer nodes={nodes} />);
+  };
+
+  it('should keep the attributes YouTube needs', () => {
+    const html = renderDelivered(
+      '<iframe width="560" height="315" src="https://www.youtube.com/embed/abc" ' +
+        'title="YouTube video player" frameborder="0" ' +
+        'allow="accelerometer; autoplay; clipboard-write; encrypted-media" ' +
+        'referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
+    );
+
+    expect(html).toContain('frameborder="0"');
+    expect(html).toContain('referrerpolicy="strict-origin-when-cross-origin"');
+    expect(html).toContain('allow="accelerometer; autoplay; clipboard-write; encrypted-media"');
+    expect(html).toContain('title="YouTube video player"');
+  });
+
+  it('should keep the attributes Google Maps needs', () => {
+    const html = renderDelivered(
+      '<iframe src="https://www.google.com/maps/embed?pb=xxx" width="600" height="450" ' +
+        'style="border:0;" allowfullscreen="" loading="lazy" ' +
+        'referrerpolicy="no-referrer-when-downgrade"></iframe>',
+    );
+
+    expect(html).toContain('style="border:0;"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('referrerpolicy="no-referrer-when-downgrade"');
+  });
+
+  it('should keep a script based embed that used to disappear entirely', () => {
+    const html = renderDelivered(
+      '<div class="hs-form-frame" data-region="na1" data-form-id="1" data-portal-id="2"></div>' +
+        '<script charset="utf-8" src="https://js.hsforms.net/forms/embed/v2.js"></script>',
+    );
+
+    expect(html).toContain('class="hs-form-frame"');
+    expect(html).toContain('data-form-id="1"');
+    expect(html).toContain(
+      '<script charset="utf-8" src="https://js.hsforms.net/forms/embed/v2.js">',
+    );
+  });
+
+  it('should keep both the quote and the widget script of an X embed', () => {
+    const html = renderDelivered(
+      '<blockquote class="twitter-tweet"><p lang="ja" dir="ltr">tweet</p>' +
+        '<a href="https://twitter.com/x/status/1">2026</a></blockquote>' +
+        '<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
+    );
+
+    expect(html).toContain('class="twitter-tweet"');
+    expect(html).toContain('src="https://platform.twitter.com/widgets.js"');
+  });
+
+  it('should leave the surrounding content parsed as usual', () => {
+    const html = renderDelivered('<div>embed</div>');
+
+    expect(html).toContain('<p>before</p>');
+    expect(html).toContain('<p>after</p>');
+  });
+});

--- a/src/parser/html-parser.test.ts
+++ b/src/parser/html-parser.test.ts
@@ -948,3 +948,90 @@ describe('data-becraft-media', () => {
     });
   });
 });
+
+describe('embed tag', () => {
+  // BeCraft の renderer は埋め込みタグの区間を HTML コメントの対で囲って配信する。
+  // 対応: apps/serverside/interface/src/renderer/embed_tag.rs
+  const wrap = (html: string) => `<!-- #embedtag -->${html}<!-- /#embedtag -->`;
+
+  it('should keep every tag and attribute of the registered html', () => {
+    // ホワイトリスト方式では frameborder / referrerpolicy が落ちていた
+    const embed =
+      '<iframe width="560" height="315" src="https://www.youtube.com/embed/xxx" ' +
+      'title="YouTube video player" frameborder="0" ' +
+      'allow="accelerometer; autoplay; clipboard-write" ' +
+      'referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>';
+    const result = parseHtml(wrap(embed));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('embedtag');
+    if (result[0].type === 'embedtag') {
+      expect(result[0].html).toContain('frameborder="0"');
+      expect(result[0].html).toContain('referrerpolicy="strict-origin-when-cross-origin"');
+      expect(result[0].html).toContain('src="https://www.youtube.com/embed/xxx"');
+    }
+  });
+
+  it('should keep script tags that the tag parser drops', () => {
+    // HubSpot のようなスクリプト方式の埋め込みは従来 1 ノードも残らなかった
+    const embed =
+      '<div class="hs-form-frame" data-region="na1" data-form-id="xxx"></div>' +
+      '<script charset="utf-8" src="https://js.hsforms.net/forms/embed/v2.js"></script>';
+    const result = parseHtml(wrap(embed));
+
+    expect(result).toHaveLength(1);
+    if (result[0].type === 'embedtag') {
+      expect(result[0].html).toContain('<script');
+      expect(result[0].html).toContain('data-form-id="xxx"');
+      expect(result[0].html).toContain('class="hs-form-frame"');
+    }
+  });
+
+  it('should treat multiple top level elements as one region', () => {
+    const result = parseHtml(wrap('<div>a</div><div>b</div>'));
+
+    expect(result).toHaveLength(1);
+    if (result[0].type === 'embedtag') {
+      expect(result[0].html).toBe('<div>a</div><div>b</div>');
+    }
+  });
+
+  it('should not swallow the surrounding content', () => {
+    const result = parseHtml(`<p>before</p>${wrap('<div>embed</div>')}<p>after</p>`);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].type).toBe('paragraph');
+    expect(result[1].type).toBe('embedtag');
+    expect(result[2].type).toBe('paragraph');
+  });
+
+  it('should parse consecutive regions independently', () => {
+    const result = parseHtml(`${wrap('<div>first</div>')}${wrap('<div>second</div>')}`);
+
+    expect(result).toHaveLength(2);
+    if (result[0].type === 'embedtag') expect(result[0].html).toBe('<div>first</div>');
+    if (result[1].type === 'embedtag') expect(result[1].html).toBe('<div>second</div>');
+  });
+
+  it('should ignore a start marker without an end marker', () => {
+    // 終端が決まらないため区間にはせず、後続の本文をそのままパースする
+    const result = parseHtml('<!-- #embedtag --><p>after</p>');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('paragraph');
+  });
+
+  it('should produce an empty html for an empty region', () => {
+    const result = parseHtml(wrap(''));
+
+    expect(result).toHaveLength(1);
+    if (result[0].type === 'embedtag') expect(result[0].html).toBe('');
+  });
+
+  it('should ignore unrelated html comments', () => {
+    const result = parseHtml('<!-- just a comment --><p>text</p>');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('paragraph');
+  });
+});

--- a/src/parser/html-parser.ts
+++ b/src/parser/html-parser.ts
@@ -12,6 +12,7 @@ import {
   VideoNode,
   AudioNode,
   EmbedNode,
+  EmbedTagNode,
   ObjectNode,
   BookmarkNode,
   ParagraphNode,
@@ -49,9 +50,10 @@ const GRID_TEMPLATE_COLS_REGEX = /grid-template-columns:\s*([^;]+)/;
 
 const isNotNull = <T>(value: T | null): value is T => value !== null;
 // Use numeric constants for Node type checks to work in both browser and Node.js environments
-// Node.ELEMENT_NODE = 1, Node.TEXT_NODE = 3
+// Node.ELEMENT_NODE = 1, Node.TEXT_NODE = 3, Node.COMMENT_NODE = 8
 const isDomElement = (node: { nodeType: number }): node is Element => node.nodeType === 1;
 const isDomTextNode = (node: { nodeType: number }): node is Text => node.nodeType === 3;
+const isDomCommentNode = (node: { nodeType: number }): node is Comment => node.nodeType === 8;
 const isListTag = (tag: string): tag is 'ul' | 'ol' => tag === 'ul' || tag === 'ol';
 const isHeadingTag = (tag: string): tag is HeadingTag =>
   tag === 'h1' || tag === 'h2' || tag === 'h3' || tag === 'h4' || tag === 'h5' || tag === 'h6';
@@ -464,6 +466,24 @@ type ParseableElement = {
   childNodes: NodeListOf<ChildNode>;
 };
 
+// 配信 API の html は全セクションを連結した 1 本の文字列になるため、埋め込みタグの
+// 区間は BeCraft の renderer が HTML コメントの対で囲って送ってくる。ここで比較するのは
+// コメントの中身なので、`<!--` `-->` を除いた本体だけを定数に持つ。
+// 対応: apps/serverside/interface/src/renderer/embed_tag.rs
+const EMBED_TAG_START_MARKER = '#embedtag';
+const EMBED_TAG_END_MARKER = '/#embedtag';
+
+const getCommentMarker = (node: ChildNode): string | null =>
+  isDomCommentNode(node) ? (node.data || '').trim() : null;
+
+// 区間内のノードを原文の HTML に戻す。埋め込みタグはタグ / 属性を一切落とさない
+// 仕様のため、パース結果ではなく元の文字列表現を復元する。
+const serializeNode = (node: ChildNode): string => {
+  if (isDomElement(node)) return node.outerHTML;
+  if (isDomCommentNode(node)) return `<!--${node.data}-->`;
+  return node.textContent || '';
+};
+
 /**
  * Parse body element's child nodes into ContentNode array.
  * This is the core parsing function used by both client and server parsers.
@@ -473,17 +493,43 @@ type ParseableElement = {
  * @internal
  */
 export const parseBodyContent = (body: ParseableElement): ContentNode[] => {
-  return Array.from(body.childNodes).flatMap((child) => {
+  const children = Array.from(body.childNodes);
+  const nodes: ContentNode[] = [];
+
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index];
+
+    if (getCommentMarker(child) === EMBED_TAG_START_MARKER) {
+      const endIndex = children.findIndex(
+        (node, i) => i > index && getCommentMarker(node) === EMBED_TAG_END_MARKER,
+      );
+
+      // 終了マーカーが無いと区間の終端が決まらない。以降の本文まで埋め込みタグに
+      // 飲まれるのを避けるため、開始マーカーだけの場合は区間として扱わない。
+      if (endIndex !== -1) {
+        const html = children
+          .slice(index + 1, endIndex)
+          .map(serializeNode)
+          .join('');
+        nodes.push(EmbedTagNode.from({ html }));
+        index = endIndex;
+        continue;
+      }
+    }
+
     if (isDomElement(child)) {
       const parsed = parseElement(child);
-      return parsed ? [parsed] : [];
+      if (parsed) nodes.push(parsed);
+      continue;
     }
+
     if (isDomTextNode(child)) {
       const text = child.textContent?.trim();
-      return text ? [TextNode.from(text, [])] : [];
+      if (text) nodes.push(TextNode.from(text, []));
     }
-    return [];
-  });
+  }
+
+  return nodes;
 };
 
 /**
@@ -502,7 +548,13 @@ export const parseHtml = (html: string): ContentNode[] => {
   }
 
   const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
+  // body を明示せずに渡すと、先頭の HTML コメントが html / head 側に移されて
+  // body から消える。埋め込みタグの区間マーカーはコメントなので、
+  // サーバー側パーサーと同じく body で囲ってから解析する。
+  const doc = parser.parseFromString(
+    `<!DOCTYPE html><html><body>${html}</body></html>`,
+    'text/html',
+  );
 
   return parseBodyContent(doc.body);
 };

--- a/src/parser/nodes.test.ts
+++ b/src/parser/nodes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { MediaNode, BookmarkNode } from './nodes';
+import { MediaNode, BookmarkNode, EmbedTagNode } from './nodes';
 
 describe('MediaNode', () => {
   describe('constructor', () => {
@@ -248,6 +248,34 @@ describe('BookmarkNode', () => {
       expect(node.type).toBe('bookmark');
       expect(node.url).toBe('https://example.com');
       expect(node.title).toBe('Title');
+    });
+  });
+});
+
+describe('EmbedTagNode', () => {
+  describe('constructor', () => {
+    it('should keep the registered html as-is', () => {
+      const html = '<iframe src="https://www.youtube.com/embed/x" frameborder="0"></iframe>';
+      const node = new EmbedTagNode({ html });
+
+      expect(node.type).toBe('embedtag');
+      expect(node.html).toBe(html);
+    });
+
+    it('should accept an empty html', () => {
+      const node = new EmbedTagNode({ html: '' });
+
+      expect(node.html).toBe('');
+    });
+  });
+
+  describe('from static method', () => {
+    it('should create EmbedTagNode from input', () => {
+      const node = EmbedTagNode.from({ html: '<div>embed</div>' });
+
+      expect(node).toBeInstanceOf(EmbedTagNode);
+      expect(node.type).toBe('embedtag');
+      expect(node.html).toBe('<div>embed</div>');
     });
   });
 });

--- a/src/parser/nodes.ts
+++ b/src/parser/nodes.ts
@@ -53,6 +53,10 @@ export type ObjectNodeInput = {
   height?: string;
 };
 
+export type EmbedTagNodeInput = {
+  html: string;
+};
+
 export type BookmarkNodeInput = {
   url: string;
   title?: string;
@@ -78,6 +82,7 @@ export type ContentNode =
   | VideoNode
   | AudioNode
   | EmbedNode
+  | EmbedTagNode
   | ObjectNode
   | BookmarkNode
   | ParagraphNode
@@ -253,6 +258,22 @@ export class EmbedNode {
 
   static from(input: EmbedNodeInput): EmbedNode {
     return new EmbedNode(input);
+  }
+}
+
+// 埋め込みタグ (BeCraft の EmbedTagValue) の区間。登録された HTML をそのまま
+// 表示する仕様のため、タグや属性を解釈せず原文の文字列として保持する。
+// HTML の <embed> を表す EmbedNode とは別物。
+export class EmbedTagNode {
+  readonly type: 'embedtag' = 'embedtag';
+  readonly html: string;
+
+  constructor(input: EmbedTagNodeInput) {
+    this.html = input.html;
+  }
+
+  static from(input: EmbedTagNodeInput): EmbedTagNode {
+    return new EmbedTagNode(input);
   }
 }
 

--- a/src/parser/server-parser-test-cases.ts
+++ b/src/parser/server-parser-test-cases.ts
@@ -180,5 +180,38 @@ export const runServerParserTests = (
       expect(result).toHaveLength(1);
       expect(result[0].type).toBe('list');
     });
+    it('should keep the registered html of an embed tag region as-is', () => {
+      const result = parseHtmlOnServer(
+        '<!-- #embedtag -->' +
+          '<div class="hs-form-frame" data-form-id="xxx"></div>' +
+          '<script charset="utf-8" src="https://js.hsforms.net/forms/embed/v2.js"></script>' +
+          '<!-- /#embedtag -->',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('embedtag');
+      if (result[0].type === 'embedtag') {
+        expect(result[0].html).toContain('<script');
+        expect(result[0].html).toContain('data-form-id="xxx"');
+      }
+    });
+
+    it('should not let an embed tag region swallow the surrounding content', () => {
+      const result = parseHtmlOnServer(
+        '<p>before</p><!-- #embedtag --><div>embed</div><!-- /#embedtag --><p>after</p>',
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result[0].type).toBe('paragraph');
+      expect(result[1].type).toBe('embedtag');
+      expect(result[2].type).toBe('paragraph');
+    });
+
+    it('should ignore an embed tag start marker without an end marker', () => {
+      const result = parseHtmlOnServer('<!-- #embedtag --><p>after</p>');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('paragraph');
+    });
   });
 };

--- a/src/renderer/html-renderer.test.tsx
+++ b/src/renderer/html-renderer.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { BeCraftHTMLRenderer } from './html-renderer';
 import { parseHtml } from '../parser/html-parser';
-import { MediaNode, BookmarkNode } from '../parser/nodes';
+import { MediaNode, BookmarkNode, EmbedTagNode } from '../parser/nodes';
 
 describe('BeCraftHTMLRenderer', () => {
   it('should render HTML paragraph', () => {
@@ -573,6 +573,57 @@ describe('BeCraftHTMLRenderer', () => {
       const { container } = render(<BeCraftHTMLRenderer nodes={[singleNode, gridNode]} />);
       const images = container.querySelectorAll('img');
       expect(images).toHaveLength(3);
+    });
+  });
+  describe('embed tag element', () => {
+    const wrap = (html: string) => `<!-- #embedtag -->${html}<!-- /#embedtag -->`;
+
+    it('should render the registered html verbatim', () => {
+      const embed =
+        '<iframe src="https://www.youtube.com/embed/xxx" frameborder="0" ' +
+        'referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>';
+      const nodes = parseHtml(wrap(embed));
+      const { container } = render(<BeCraftHTMLRenderer nodes={nodes} />);
+
+      const iframe = container.querySelector('iframe');
+      expect(iframe).toBeTruthy();
+      expect(iframe?.getAttribute('src')).toBe('https://www.youtube.com/embed/xxx');
+      expect(iframe?.getAttribute('frameborder')).toBe('0');
+      expect(iframe?.getAttribute('referrerpolicy')).toBe('strict-origin-when-cross-origin');
+      expect(iframe?.hasAttribute('allowfullscreen')).toBe(true);
+    });
+
+    it('should render multiple top level elements of one region', () => {
+      const nodes = parseHtml(wrap('<div class="a">a</div><div class="b">b</div>'));
+      const { container } = render(<BeCraftHTMLRenderer nodes={nodes} />);
+
+      expect(container.querySelector('.a')?.textContent).toBe('a');
+      expect(container.querySelector('.b')?.textContent).toBe('b');
+    });
+
+    it('should not sanitize urls inside an embed tag', () => {
+      // 埋め込みタグは登録された html をそのまま通す仕様のため、
+      // 他ノードのような sanitizeUrl を適用しない
+      const node = EmbedTagNode.from({ html: '<a href="javascript:alert(1)">x</a>' });
+      const { container } = render(<BeCraftHTMLRenderer nodes={[node]} />);
+
+      expect(container.querySelector('a')?.getAttribute('href')).toBe('javascript:alert(1)');
+    });
+
+    it('should use a custom embedTagNodeRenderer when configured', () => {
+      const node = EmbedTagNode.from({ html: '<div>raw</div>' });
+      const { container } = render(
+        <BeCraftHTMLRenderer
+          nodes={[node]}
+          config={{
+            embedTagNodeRenderer: ({ node: n }) => <section data-html={n.html}>custom</section>,
+          }}
+        />,
+      );
+
+      const section = container.querySelector('section');
+      expect(section?.textContent).toBe('custom');
+      expect(section?.getAttribute('data-html')).toBe('<div>raw</div>');
     });
   });
 });

--- a/src/renderer/html-renderer.tsx
+++ b/src/renderer/html-renderer.tsx
@@ -10,6 +10,7 @@ import {
   type VideoNode,
   type AudioNode,
   type EmbedNode,
+  type EmbedTagNode,
   type ObjectNode,
   type BookmarkNode,
   type ParagraphNode,
@@ -57,6 +58,7 @@ export interface HTMLRendererConfig {
   videoNodeRenderer?: React.FC<NodeRendererProps<VideoNode>>;
   audioNodeRenderer?: React.FC<NodeRendererProps<AudioNode>>;
   embedNodeRenderer?: React.FC<NodeRendererProps<EmbedNode>>;
+  embedTagNodeRenderer?: React.FC<NodeRendererProps<EmbedTagNode>>;
   objectNodeRenderer?: React.FC<NodeRendererProps<ObjectNode>>;
   bookmarkNodeRenderer?: React.FC<NodeRendererProps<BookmarkNode>>;
   paragraphNodeRenderer?: React.FC<NodeRendererProps<ParagraphNode>>;
@@ -221,6 +223,21 @@ const EmbedNodeRenderer: React.FC<NodeRendererProps<EmbedNode>> = ({ node, confi
       height={node.height}
     />
   );
+};
+
+const EmbedTagNodeRenderer: React.FC<NodeRendererProps<EmbedTagNode>> = ({ node, config }) => {
+  if (config?.embedTagNodeRenderer) {
+    return config.embedTagNodeRenderer({ node, render: renderNode, config });
+  }
+
+  // 「登録した HTML がそのまま表示される」という仕様のため、サニタイズも
+  // 属性の絞り込みもせず原文を挿入する。埋め込み値の安全性は BeCraft の
+  // 編集権限で担保する前提。
+  //
+  // なお innerHTML 経由で挿入された <script> は HTML 仕様上実行されない。
+  // script の実行が要る埋め込み (HubSpot フォーム等) を扱うテナントは
+  // embedTagNodeRenderer で独自に処理する。
+  return <div dangerouslySetInnerHTML={{ __html: node.html }} />;
 };
 
 const ObjectNodeRenderer: React.FC<NodeRendererProps<ObjectNode>> = ({ node, config }) => {
@@ -550,6 +567,8 @@ const renderNode: RenderFn = (node, config) => {
       return <AudioNodeRenderer node={node} render={renderNode} config={config} />;
     case 'embed':
       return <EmbedNodeRenderer node={node} render={renderNode} config={config} />;
+    case 'embedtag':
+      return <EmbedTagNodeRenderer node={node} render={renderNode} config={config} />;
     case 'object':
       return <ObjectNodeRenderer node={node} render={renderNode} config={config} />;
     case 'bookmark':


### PR DESCRIPTION
## 概要

埋め込みタグセクションに登録された HTML を、タグ・属性を一切落とさずそのまま描画できるようにする。

配信 API 側は [framgia/becraft#1818](https://github.com/framgia/becraft/pull/1818) で、埋め込みタグの区間を HTML コメントで囲って送るようになった。本 PR はその区間を SDK で検出して原文を保持する対応。

```
<p>本文</p><!-- #embedtag --><iframe ...></iframe><!-- /#embedtag --><p>本文</p>
```

## 背景

パーサーがタグと属性のホワイトリストを通していたため、登録した HTML がそのまま表示されていなかった。実測した欠落は以下。

| 埋め込み元 | 欠落していたもの |
|---|---|
| YouTube | `frameborder` / `referrerpolicy` |
| Google Maps | `style` / `loading` / `referrerpolicy` |
| HubSpot | **ノードが 1 つも残らない**（`<script>` 方式のため） |
| X (Twitter) | 引用部分のみ残り、ウィジェット `<script>` が消える |

`<script>` / `<style>` は `// Security risk, not supported intentionally` として意図的に落とされていた。

## 変更点

- `EmbedTagNode` を追加。原文の HTML を `html` として保持する
  - HTML の `<embed>` を表す既存の `EmbedNode` とは別物
- `parseBodyContent` が `<!-- #embedtag -->` 〜 `<!-- /#embedtag -->` を 1 区間として検出する
  - 終了マーカーが無い場合は区間として扱わない（後続の本文を巻き込まないため）
  - 区間内は `outerHTML` で原文へ復元するので、タグ・属性は加工されない
- `parseHtml`（ブラウザ）も `<body>` で囲ってから解析するよう変更
  - 囲まないと先頭の HTML コメントが `head` 側へ移り body から消えるため。サーバー側パーサーと同じ形に揃えた
- 描画は `dangerouslySetInnerHTML`。`embedTagNodeRenderer` で差し替え可能

## 制約

`innerHTML` 経由で挿入された `<script>` は HTML 仕様上実行されない。DOM 上には残るため取り出せるが、スクリプトの実行が要る埋め込み（HubSpot フォーム等）を扱うテナントは `embedTagNodeRenderer` で独自に処理する必要がある。README に明記した。

## テスト

`pnpm test` — **7 files / 218 tests 通過**（追加 34 件）。

- `embed-tag-round-trip.test.tsx` — 配信 API と同じ形の html を入力に、パース〜描画を通して YouTube / Google Maps / HubSpot / X の原文が保たれることを確認
- client (jsdom) / server (linkedom) の両パーサーで区間検出を確認
- 開始マーカーのみ・空区間・連続区間・前後本文の非巻き込みを確認

## 関連

- 形式仕様: `specs/content/embed_tag.als` の `MarkerBasedPassthrough`
- Issue: framgia/becraft#1817
- 配信 API 側: framgia/becraft#1818

🤖 Generated with [Claude Code](https://claude.com/claude-code)